### PR TITLE
Basic responsive enabled in Preview mode

### DIFF
--- a/app/manifest.json
+++ b/app/manifest.json
@@ -44,6 +44,18 @@
       ],
       "run_at": "document_start",
       "all_frames": false
+    },
+    {
+      "matches": [
+        "*://*.demo.magentosite.cloud/admin/staging/*"
+      ],
+      "js": [
+        "scripts/preview.processed.js"
+      ],
+      "css": [
+        "styles/preview.css"
+      ],
+      "run_at": "document_idle"
     }
   ],
   "browser_action": {

--- a/app/scripts/preview/resizer.js
+++ b/app/scripts/preview/resizer.js
@@ -1,0 +1,29 @@
+var MCPreview = {
+	addButtons: function() {
+		var target = document.querySelector(".staging-update-preview .staging-preview-options");
+
+		var buttonGroup = document.createElement('div');
+		buttonGroup.classList.add("staging-preview-item-resize");
+		buttonGroup.innerHTML = '<a href="#" class="resizeMobile">mobile</a><a href="#" class="resizeTablet">tablet</a><a href="#" class="resizeDefault">default</a>';
+
+		target.appendChild(buttonGroup);
+
+		var mobileButton = document.querySelector(".staging-update-preview .resizeMobile");
+		var tabletButton = document.querySelector(".staging-update-preview .resizeTablet");
+		var desktopButton = document.querySelector(".staging-update-preview .resizeDefault");
+		mobileButton.addEventListener('click', function(){ MCPreview.addDynamicClass('mobile'); }, false);
+		tabletButton.addEventListener('click', function(){ MCPreview.addDynamicClass('tablet'); }, false);
+		desktopButton.addEventListener('click', function(){ MCPreview.addDynamicClass(''); }, false);
+
+	},
+
+	addDynamicClass: function(className) {
+		var contentDynamic = document.querySelector(".staging-preview-content-dynamic");
+		contentDynamic.classList.remove('mobile');
+		contentDynamic.classList.remove('tablet');
+		contentDynamic.classList.add(className);
+	}
+
+}
+
+MCPreview.addButtons();

--- a/app/styles.scss/preview.scss
+++ b/app/styles.scss/preview.scss
@@ -1,0 +1,53 @@
+body.staging-update-preview {
+	/* Remove the forced width so Chrome browser tools can be used */
+	min-width: initial;
+
+	@media only screen and (max-width: 500px) {
+		/* Shrink header items when viewing using browser tools */
+		.staging-preview-header {
+			.logo {
+				margin: 1.8rem 1.5rem;
+			}
+			.staging-preview-item-title {
+				padding: 1.5rem 2rem;
+			}
+		}
+	}
+
+	@media only screen and (max-width: 800px) {
+		/* Shrink header items when viewing using browser tools */
+		.staging-preview-header {
+			.staging-preview-item-resize {
+				display: none;
+			}
+		}
+	}
+
+	.staging-preview-item-resize {
+	    cursor: pointer;
+	    float: right;
+	    font-size: 1.3rem;
+	    min-height: 8.5rem;
+	    padding: 1.5rem 4rem 2.5rem;
+	    position: relative;
+	    a {
+			display: inline-block;
+			text-transform: uppercase;
+			color: #c3bbb1;
+			padding: 0 1rem;
+			&:hover, &:active {
+				color: #c3bbb1;
+			}
+		}
+	}
+
+	.staging-preview-content-dynamic {
+		&.mobile {
+			max-width: 320px;
+		}
+		&.tablet {
+			max-width: 640px;
+		}
+	}
+	
+}

--- a/gulpfile.babel.js
+++ b/gulpfile.babel.js
@@ -35,6 +35,10 @@ const contentScripts = [
   'app/scripts/content/document-start.js'
 ]
 
+const previewScripts = [
+  'app/scripts/preview/resizer.js'
+]
+
 const distBackgroundScripts = [
   'app/scripts/lib/lib.js',
   'app/scripts/background/my-background.js',
@@ -113,12 +117,18 @@ for (let mode of ['dev', 'dist']) {
       file: 'popup.processed.js',
       ...(mode === 'dev' ? devOpts : distOpts)
     })
+    processJS({
+      srcs: previewScripts,
+      file: 'preview.processed.js',
+      ...(mode === 'dev' ? devOpts : distOpts)
+    })
   })
 
   gulp.task(mode + '-styles', () =>
     gulp.src([
         'app/styles.scss/main.scss',
         'app/styles.scss/content.scss',
+        'app/styles.scss/preview.scss',
       ])
       .pipe($.plumber())
       .pipe($.if(mode === 'dev', $.sourcemaps.init()))


### PR DESCRIPTION
Reset forced CSS width, added quick resize links, tidied up some styles.

When in Content Staging Preview browser couldn't be resized to see mobile view (even dev tools), because of a single CSS rule forcing page width, which as been removed. Also added some basic JS links to provide 'in page' resizing to 320px and 640px, can be improved drastically, but enough to show it can be done.